### PR TITLE
Add dhp to rollHitDie.

### DIFF
--- a/module/documents/actor/actor.mjs
+++ b/module/documents/actor/actor.mjs
@@ -1309,8 +1309,11 @@ export default class Actor5e extends Actor {
      */
     if ( Hooks.call("dnd5e.rollHitDie", this, roll, updates) === false ) return roll;
 
+    // Re-evaluate dhp in the event that it was changed in the previous hook
+    const updateOptions = { dhp: (updates.actor?.["system.attributes.hp.value"] ?? hp.value) - hp.value };
+
     // Perform updates
-    if ( !foundry.utils.isEmpty(updates.actor) ) await this.update(updates.actor);
+    if ( !foundry.utils.isEmpty(updates.actor) ) await this.update(updates.actor, updateOptions);
     if ( !foundry.utils.isEmpty(updates.class) ) await cls.update(updates.class);
 
     return roll;


### PR DESCRIPTION
- add updateOptions for dhp.
- dhp evaluated in case it is changed in preceding hook.

An attempt to resolve https://github.com/foundryvtt/dnd5e/issues/1456