### PR TITLE
Allow all actor owners to use non-Saving Throw buttons in chat instead of only Message Authors

### DIFF
--- a/module/documents/item.mjs
+++ b/module/documents/item.mjs
@@ -1815,13 +1815,13 @@ export default class Item5e extends Item {
     const message = game.messages.get(messageId);
     const action = button.dataset.action;
 
-    // Validate permission to proceed with the roll
-    const isTargetted = action === "save";
-    if ( !( isTargetted || game.user.isGM || message.isAuthor ) ) return;
-
     // Recover the actor for the chat card
     const actor = await this._getChatCardActor(card);
     if ( !actor ) return;
+
+    // Validate permission to proceed with the roll
+    const isTargetted = action === "save";
+    if ( !( isTargetted || game.user.isGM || actor.isOwner ) ) return;
 
     // Get the Item from stored flag data or by the item ID on the Actor
     const storedData = message.getFlag("dnd5e", "itemData");


### PR DESCRIPTION
- swapped position of checks.
- changed author check for owner check.

An attempt to resolve https://github.com/foundryvtt/dnd5e/issues/1145